### PR TITLE
Mudança de tipos primitivos

### DIFF
--- a/src/main/java/com/example/SCCO_MVC/model/entity/Agenda.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Agenda.java
@@ -21,4 +21,7 @@ public class Agenda {
     @OneToOne
     private Disponibilidade disponibilidade;
 
+    @OneToOne
+    private Dentista dentista;
+
 }

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Consulta.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Consulta.java
@@ -30,7 +30,7 @@ public class Consulta {
     @ManyToOne
     private Agenda agenda;
 
-    private double valorConsulta;
+    private Double valorConsulta;
     private Date data;
     private Time horaInicio;
     private Time horaFim;

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Dentista.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Dentista.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 public class Dentista extends Pessoa {
 
     private Integer cro;
-    private String agenda;
 
     @ManyToOne
     private Especialidade especialidade;

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Dentista.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Dentista.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 
 public class Dentista extends Pessoa {
 
-    private Integer cro;
+    private String cro;
 
     @ManyToOne
     private Especialidade especialidade;

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Disponibilidade.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Disponibilidade.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.sql.Time;
-import java.util.List;
 
 @Entity
 @Data

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Endereco.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Endereco.java
@@ -23,7 +23,7 @@ public class Endereco {
     private String bairro;
     private String uf;
     private String cidade;
-    private Integer numero;
+    private String numero;
     private String complemento;
     private String cep;
 

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Procedimento.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Procedimento.java
@@ -17,8 +17,8 @@ public class Procedimento {
     private Long id;
 
     private String nome;
-    private boolean status;
-    private double valor;
+    private Boolean status;
+    private Double valor;
 
     @ManyToOne
     private Especialidade especialidade;

--- a/src/main/java/com/example/SCCO_MVC/model/entity/Tratamento.java
+++ b/src/main/java/com/example/SCCO_MVC/model/entity/Tratamento.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 
 @Entity
 @Data


### PR DESCRIPTION
Existem alguns atributos, como por exemplo o cro na classe ```Dentista``` que estavam no tipo primitivo ```Integer```.
Como esses número não serão utilizados em nenhum tipo de cálculo, acredito que seja melhor para trabalhar com eles no tipo primitivo ```String```.

Outro motivo desse PR é o fato de o atributo agenda na classe ```Dentista``` estar sendo tratado como ```String``` e não como um objeto.

> **Warning**
Como foram mudanças nas classes de entidade, estas certamente afetaram nossa base de dados, então talvez alguma coluna/linha/tabela tenha que ser deletada manualmente.